### PR TITLE
Fix installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,20 @@ Configure your ShipStation integration:
 
 ```ruby
 # config/initializers/solidus_shipstation.rb
+
 SolidusShipstation.configure do |config|
   # Choose between Grams, Ounces or Pounds.
-  config.shipstation_weight_units = "Grams"
+  config.weight_units = "Grams"
 
   # ShipStation expects the endpoint to be protected by HTTP Basic Auth.
   # Set the username and password you desire for ShipStation to use.
-  config.shipstation_username = "smoking_jay_cutler"
-  config.shipstation_password = "my-awesome-password"
-
-  # Turn SSL on/off for testing and development purposes.
-  config.shipstation_ssl_encrypted = !Rails.env.development?
+  config.username = "smoking_jay_cutler"
+  config.password = "my-awesome-password"
 
   # Capture payment when ShipStation notifies a shipping label creation.
-  # Set this to `true` and `require_payment_to_ship` to `false` if you
+  # Set this to `true` and `Spree::Configrequire_payment_to_ship` to `false` if you
   # want to charge your customers at the time of shipment.
-  config.shipstation_capture_at_notification = false
+  config.capture_at_notification = false
 end
 ```
 
@@ -59,7 +57,7 @@ Spree.config do |config|
   config.require_payment_to_ship = true
 
   # Set to false if you're not using inventory tracking features (defaults to true).
-  config.track_inventory_levels = true 
+  config.track_inventory_levels = true
 end
 ```
 
@@ -74,7 +72,7 @@ Enter the following details:
 - **Password**: the password defined in your config.
 - **URL to custom page**: `https://yourdomain.com/shipstation.xml`.
 
-There are five shipment states for an order (= shipment) in ShipStation. These states do not 
+There are five shipment states for an order (= shipment) in ShipStation. These states do not
 necessarily align with Solidus, but you can configure ShipStation to create a mapping for your
 specific needs. Here's the default mapping:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that adds Solidus and Rails 4.2+ compatibility.
 Add solidus_shipstation to your Gemfile:
 
 ```ruby
-gem 'solidus_shipstation'
+gem 'solidus_shipstation', github: 'solidusio-contrib/solidus_shipstation'
 ```
 
 Bundle your dependencies and run the installation generator:

--- a/lib/generators/solidus_shipstation/install/install_generator.rb
+++ b/lib/generators/solidus_shipstation/install/install_generator.rb
@@ -3,30 +3,6 @@
 module SolidusShipstation
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      class_option :auto_run_migrations, type: :boolean, default: false
-
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/solidus_shipstation/frontend/all.js', "//= require solidus_shipstation/frontend/solidus_shipstation\n"
-        append_file 'vendor/assets/javascripts/solidus_shipstation/backend/all.js', "//= require solidus_shipstation/backend/solidus_shipstation\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/solidus_shipstation/frontend/all.css', " *= require solidus_shipstation/frontend/solidus_shipstation\n", before: %r{\*/}, verbose: true
-        inject_into_file 'vendor/assets/stylesheets/solidus_shipstation/backend/all.css', " *= require solidus_shipstation/backend/solidus_shipstation\n", before: %r{\*/}, verbose: true
-      end
-
-      def add_migrations
-        run 'bin/rails railties:install:migrations FROM=solidus_shipstation'
-      end
-
-      def run_migrations
-        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
-        if run_migrations
-          run 'bin/rails db:migrate'
-        else
-          puts 'Skipping bin/rails db:migrate, don\'t forget to run it!' # rubocop:disable Rails/Output
-        end
-      end
     end
   end
 end

--- a/lib/generators/solidus_shipstation/install/install_generator.rb
+++ b/lib/generators/solidus_shipstation/install/install_generator.rb
@@ -3,6 +3,11 @@
 module SolidusShipstation
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
+      def generate_shipstation_configuration_file
+        copy_file 'config/initializers/solidus_shipstation.rb', 'config/initializers/solidus_shipstation.rb', skip: true
+      end
     end
   end
 end

--- a/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
+++ b/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+SolidusShipstation.configure do |config|
+  # Choose between Grams, Ounces or Pounds.
+  config.shipstation_weight_units = "Grams"
+
+  # ShipStation expects the endpoint to be protected by HTTP Basic Auth.
+  # Set the username and password you desire for ShipStation to use.
+  config.shipstation_username = "smoking_jay_cutler"
+  config.shipstation_password = "my-awesome-password"
+
+  # Turn SSL on/off for testing and development purposes.
+  config.shipstation_ssl_encrypted = !Rails.env.development?
+
+  # Capture payment when ShipStation notifies a shipping label creation.
+  # Set this to `true` and `require_payment_to_ship` to `false` if you
+  # want to charge your customers at the time of shipment.
+  config.shipstation_capture_at_notification = false
+end

--- a/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
+++ b/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
@@ -2,18 +2,15 @@
 
 SolidusShipstation.configure do |config|
   # Choose between Grams, Ounces or Pounds.
-  config.shipstation_weight_units = "Grams"
+  config.weight_units = "Grams"
 
   # ShipStation expects the endpoint to be protected by HTTP Basic Auth.
   # Set the username and password you desire for ShipStation to use.
-  config.shipstation_username = "smoking_jay_cutler"
-  config.shipstation_password = "my-awesome-password"
-
-  # Turn SSL on/off for testing and development purposes.
-  config.shipstation_ssl_encrypted = !Rails.env.development?
+  config.username = "smoking_jay_cutler"
+  config.password = "my-awesome-password"
 
   # Capture payment when ShipStation notifies a shipping label creation.
-  # Set this to `true` and `require_payment_to_ship` to `false` if you
+  # Set this to `true` and `Spree::Config.require_payment_to_ship` to `false` if you
   # want to charge your customers at the time of shipment.
-  config.shipstation_capture_at_notification = false
+  config.capture_at_notification = false
 end


### PR DESCRIPTION
- Use GitHub version to install this extension: the released one is outdated and we need to wait for past maintainers
to provide the access to that gem

- Fix installer removing useless assets and migrations: this extension has no assets or migrations to copy on the
host application. This wrong behavior was also raising an
error trying to install the extension since the files it
was trying to copy do not exist.

- Copy the configuration file while installing: this is a required step and we can save some time when installing the
gem providing the same default we are describing in the README.
