### PR TITLE
Fix shipment tracking number not being propagated to carton

### DIFF
--- a/lib/solidus_shipstation/shipment_notice.rb
+++ b/lib/solidus_shipstation/shipment_notice.rb
@@ -50,8 +50,9 @@ module SolidusShipstation
     end
 
     def ship_shipment
+      shipment.update!(tracking: shipment_tracking)
       shipment.ship!
-      shipment.update!(tracking: shipment_tracking, shipped_at: Time.zone.now)
+      shipment.update!(shipped_at: Time.zone.now)
       shipment.order.recalculate
     end
   end

--- a/lib/solidus_shipstation/shipment_notice.rb
+++ b/lib/solidus_shipstation/shipment_notice.rb
@@ -52,7 +52,6 @@ module SolidusShipstation
     def ship_shipment
       shipment.update!(tracking: shipment_tracking)
       shipment.ship!
-      shipment.update!(shipped_at: Time.zone.now)
       shipment.order.recalculate
     end
   end

--- a/spec/lib/solidus_shipstation/shipment_notice_spec.rb
+++ b/spec/lib/solidus_shipstation/shipment_notice_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe SolidusShipstation::ShipmentNotice do
           shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
           shipment_notice.apply
 
-          order.reload
-          expect(order.shipments.first).to be_shipped
-          expect(order.shipments.first.tracking).to eq('1Z1231234')
+          expect_order_to_be_shipped(order)
         end
       end
 
@@ -38,9 +36,7 @@ RSpec.describe SolidusShipstation::ShipmentNotice do
             shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
             shipment_notice.apply
 
-            order.reload
-            expect(order.shipments.first).to be_shipped
-            expect(order.shipments.first.tracking).to eq('1Z1231234')
+            expect_order_to_be_shipped(order)
           end
         end
 
@@ -69,9 +65,7 @@ RSpec.describe SolidusShipstation::ShipmentNotice do
           shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
           shipment_notice.apply
 
-          order.reload
-          expect(order.shipments.first).to be_shipped
-          expect(order.shipments.first.tracking).to eq('1Z1231234')
+          expect_order_to_be_shipped(order)
         end
       end
 
@@ -106,5 +100,13 @@ RSpec.describe SolidusShipstation::ShipmentNotice do
       shipment_number: shipment.number,
       shipment_tracking: shipment_tracking,
     )
+  end
+
+  def expect_order_to_be_shipped(order)
+    order.reload
+    expect(order.shipments.first).to be_shipped
+    expect(order.shipments.first.shipped_at).not_to be_nil
+    expect(order.shipments.first.tracking).to eq('1Z1231234')
+    expect(order.cartons.first.tracking).to eq('1Z1231234')
   end
 end


### PR DESCRIPTION
This PR fixes an issue where a shipment's tracking number was not being propagated to the carton that was created for the shipment. It was just a minor problem with the order of operations.