### PR TITLE
Add configuration to export canceled shipments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ SolidusShipstation.configure do |config|
   # Set this to `true` and `Spree::Configrequire_payment_to_ship` to `false` if you
   # want to charge your customers at the time of shipment.
   config.capture_at_notification = false
+
+  # Export canceled shipments to ShipStation
+  # Set this to `true` if you want canceled shipments included in the endpoint.
+  config.export_canceled_shipments = false
 end
 ```
 

--- a/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
@@ -12,10 +12,13 @@ module SolidusShipstation
           query = order(:updated_at)
                   .joins(:order)
                   .merge(::Spree::Order.complete)
-                  .where.not(spree_shipments: { state: 'canceled' })
 
           unless SolidusShipstation.configuration.capture_at_notification
-            query = query.ready
+            query = query.where(spree_shipments: { state: ['ready', 'canceled'] })
+          end
+
+          unless SolidusShipstation.configuration.export_canceled_shipments
+            query = query.where.not(spree_shipments: { state: 'canceled' })
           end
 
           query

--- a/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
+++ b/lib/generators/solidus_shipstation/install/templates/config/initializers/solidus_shipstation.rb
@@ -13,4 +13,8 @@ SolidusShipstation.configure do |config|
   # Set this to `true` and `Spree::Config.require_payment_to_ship` to `false` if you
   # want to charge your customers at the time of shipment.
   config.capture_at_notification = false
+
+  # Export canceled shipments to ShipStation
+  # Set this to `true` if you want canceled shipments included in the endpoint.
+  config.export_canceled_shipments = false
 end

--- a/lib/solidus_shipstation/configuration.rb
+++ b/lib/solidus_shipstation/configuration.rb
@@ -2,6 +2,7 @@
 
 module SolidusShipstation
   class Configuration
-    attr_accessor :username, :password, :weight_units, :ssl_encrypted, :capture_at_notification
+    attr_accessor :username, :password, :weight_units, :ssl_encrypted, :capture_at_notification,
+      :export_canceled_shipments
   end
 end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -30,25 +30,53 @@ RSpec.describe Spree::Shipment do
   end
 
   describe '.exportable' do
-    context 'when capture_at_notification is false' do
+    context 'when capture_at_notification is false and export_canceled_shipments is false' do
       it 'returns ready shipments from complete orders' do
-        stub_configuration(capture_at_notification: false)
+        stub_configuration(capture_at_notification: false, export_canceled_shipments: false)
 
         ready_shipment = create(:order_ready_to_ship).shipments.first
-        create(:shipped_order).shipments.first
+        create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
+        create(:shipped_order)
 
         expect(described_class.exportable).to eq([ready_shipment])
       end
     end
 
-    context 'when capture_at_notification is true' do
+    context 'when capture_at_notification is true and export_canceled_shipments is false' do
       it 'returns non-canceled shipments from complete orders' do
-        stub_configuration(capture_at_notification: false)
+        stub_configuration(capture_at_notification: true, export_canceled_shipments: false)
 
-        pending_shipment = create(:order_ready_to_ship).shipments.first
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        shipped_shipment = create(:shipped_order).shipments.first
         create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
 
-        expect(described_class.exportable).to eq([pending_shipment])
+        expect(described_class.exportable).to eq([ready_shipment, shipped_shipment])
+      end
+    end
+
+    context 'when capture_at_notification is false and export_canceled_shipments is true' do
+      it 'returns ready and canceled shipments from complete orders' do
+        stub_configuration(capture_at_notification: false, export_canceled_shipments: true)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment.cancel!
+        create(:shipped_order)
+
+        expect(described_class.exportable).to eq([ready_shipment, canceled_shipment])
+      end
+    end
+
+    context 'when capture_at_notification is true and export_canceled_shipments is true' do
+      it 'returns all shipments from complete orders' do
+        stub_configuration(capture_at_notification: true, export_canceled_shipments: true)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment.cancel!
+        shipped_shipment = create(:shipped_order).shipments.first
+
+        expect(described_class.exportable).to eq([ready_shipment, canceled_shipment, shipped_shipment])
       end
     end
   end


### PR DESCRIPTION
The XML exported to ShipStation didn't consider the canceled shipments. It prevented the shipments' updates to the canceled state on the platform. This PR adds a configuration to expose these shipments in the XML.

Table with cases: 

capture_at_notification | export_canceled_shipments | exported states
------------ | ------------- | -------------
true | true | any state
false | true | canceled OR ready
true | false | NOT canceled
false | false | ready
