### PR TITLE
Fix README inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ShipStation description | ShipStation status | Solidus status
 Awaiting Payment        | `unpaid`           | `pending`
 Awaiting Shipment       | `paid`             | `ready`
 Shipped                 | `shipped`          | `shipped`
-Cancelled               | `cancelled`        | `cancelled`
+Cancelled               | `cancelled`        | `canceled`
 On-Hold                 | `on-hold`          | `pending`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ There are a few gotchas you need to be aware of:
 
 - If you change the shipping method of an order in ShipStation, the change will not be reflected in
   Solidus and the tracking link might not work properly.
-- When `shipstation_capture_at_notification` is enabled, any errors during payment capture will
+- When `capture_at_notification` is enabled, any errors during payment capture will
   prevent the update of the shipment's tracking number.
 
 ## Development


### PR DESCRIPTION
This PR fixes a few inconsistencies in the README:

* A mention to the `capture_at_notification` configuration as `shipstation_capture_at_notification`
* The `canceled` Solidus status as `cancelled`