### PR TITLE
Fix ShipmentNotice not handling double shipments

### DIFF
--- a/lib/solidus_shipstation/shipment_notice.rb
+++ b/lib/solidus_shipstation/shipment_notice.rb
@@ -51,7 +51,7 @@ module SolidusShipstation
 
     def ship_shipment
       shipment.update!(tracking: shipment_tracking)
-      shipment.ship!
+      shipment.ship! if shipment.can_ship?
       shipment.order.recalculate
     end
   end

--- a/spec/lib/solidus_shipstation/shipment_notice_spec.rb
+++ b/spec/lib/solidus_shipstation/shipment_notice_spec.rb
@@ -1,141 +1,90 @@
 # frozen_string_literal: true
 
 RSpec.describe SolidusShipstation::ShipmentNotice do
-  describe '#apply' do
-    context 'when capture_at_notification is true' do
-      context 'when the order is paid' do
-        context 'when the order was not shipped yet' do
-          it 'ships the order successfully' do
-            stub_configuration(capture_at_notification: true)
-            order = create_order_ready_to_ship(paid: true)
+  shared_examples 'ships or updates the shipment' do
+    context 'when the order was not shipped yet' do
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'ships the order successfully' do
+        shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
+        shipment_notice.apply
 
-            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-            shipment_notice.apply
+        order.reload
+        expect(order.shipments.first).to be_shipped
+        expect(order.shipments.first.shipped_at).not_to be_nil
+        expect(order.shipments.first.tracking).to eq('1Z1231234')
+        expect(order.cartons.first.tracking).to eq('1Z1231234')
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+    end
 
-            expect_order_to_be_shipped(order)
-          end
-        end
+    context 'when the order was already shipped' do
+      it 'updates the tracking number on the shipment' do
+        order.shipments.first.ship!
 
-        context 'when the order was already shipped' do
-          it 'updates the tracking number on the shipment' do
-            stub_configuration(capture_at_notification: true)
-            order = create_order_ready_to_ship(paid: true)
-            order.shipments.first.ship!
+        shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
+        shipment_notice.apply
 
-            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-            shipment_notice.apply
+        expect(order.reload.shipments.first.tracking).to eq('1Z1231234')
+      end
+    end
+  end
 
-            expect(order.reload.shipments.first.tracking).to eq('1Z1231234')
-          end
+  context 'when capture_at_notification is true' do
+    before { stub_configuration(capture_at_notification: true) }
+
+    context 'when the order is paid' do
+      let(:order) { create_order_ready_to_ship(paid: true) }
+
+      include_examples 'ships or updates the shipment'
+    end
+
+    context 'when the order is not paid' do
+      let(:order) { create_order_ready_to_ship(paid: false) }
+
+      context 'when the payment can be captured successfully' do
+        include_examples 'ships or updates the shipment'
+
+        it 'pays the order successfully' do
+          shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
+          shipment_notice.apply
+
+          order.reload
+          expect(order.payments).to all(be_completed)
+          expect(order.reload).to be_paid
         end
       end
 
-      context 'when the order is not paid' do
-        context 'when the payments can be captured successfully' do
-          context 'when the order was not shipped yet' do
-            it 'pays the order successfully' do
-              stub_configuration(capture_at_notification: true)
-              order = create_order_ready_to_ship(paid: false)
+      context 'when the payment cannot be captured' do
+        it 'raises a PaymentError' do
+          allow_any_instance_of(Spree::Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
 
-              shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-              shipment_notice.apply
+          shipment_notice = build_shipment_notice(order.shipments.first)
 
-              order.reload
-              expect(order.payments).to all(be_completed)
-              expect(order.reload).to be_paid
-            end
-
-            it 'ships the order successfully' do
-              stub_configuration(capture_at_notification: true)
-              order = create_order_ready_to_ship(paid: false)
-
-              shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-              shipment_notice.apply
-
-              expect_order_to_be_shipped(order)
-            end
-          end
-
-          context 'when the order was already shipped' do
-            it 'pays the order successfully' do
-              stub_configuration(capture_at_notification: true)
-              order = create_order_ready_to_ship(paid: false)
-              order.shipments.first.ship!
-
-              shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-              shipment_notice.apply
-
-              order.reload
-              expect(order.payments).to all(be_completed)
-              expect(order.reload).to be_paid
-            end
-
-            it 'updates the tracking number on the shipment' do
-              stub_configuration(capture_at_notification: true)
-              order = create_order_ready_to_ship(paid: false)
-              order.shipments.first.ship!
-
-              shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-              shipment_notice.apply
-
-              expect(order.reload.shipments.first.tracking).to eq('1Z1231234')
-            end
-          end
-        end
-
-        context 'when the a payment cannot be captured' do
-          it 'raises a PaymentError' do
-            stub_configuration(capture_at_notification: true)
-            order = create_order_ready_to_ship(paid: false)
-            allow_any_instance_of(Spree::Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
-
-            shipment_notice = build_shipment_notice(order.shipments.first)
-
-            expect { shipment_notice.apply }.to raise_error(SolidusShipstation::PaymentError) do |e|
-              expect(e.cause).to be_instance_of(Spree::Core::GatewayError)
-            end
+          expect { shipment_notice.apply }.to raise_error(SolidusShipstation::PaymentError) do |e|
+            expect(e.cause).to be_instance_of(Spree::Core::GatewayError)
           end
         end
       end
     end
+  end
 
-    context 'when capture_at_notification is false' do
-      context 'when the order is paid' do
-        context 'when the order was already shipped' do
-          it 'updates the tracking number on the shipment' do
-            stub_configuration(capture_at_notification: false)
-            order = create_order_ready_to_ship(paid: true)
-            order.shipments.first.ship!
+  context 'when capture_at_notification is false' do
+    before { stub_configuration(capture_at_notification: false) }
 
-            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-            shipment_notice.apply
+    context 'when the order is paid' do
+      let(:order) { create_order_ready_to_ship(paid: true) }
 
-            expect(order.reload.shipments.first.tracking).to eq('1Z1231234')
-          end
-        end
+      include_examples 'ships or updates the shipment'
+    end
 
-        context 'when the order was not shipped yet' do
-          it 'ships the order successfully' do
-            stub_configuration(capture_at_notification: false)
-            order = create_order_ready_to_ship(paid: true)
+    context 'when the order is not paid' do
+      it 'raises an OrderNotPaidError' do
+        stub_configuration(capture_at_notification: false)
+        order = create_order_ready_to_ship(paid: false)
 
-            shipment_notice = build_shipment_notice(order.shipments.first, shipment_tracking: '1Z1231234')
-            shipment_notice.apply
+        shipment_notice = build_shipment_notice(order.shipments.first)
 
-            expect_order_to_be_shipped(order)
-          end
-        end
-      end
-
-      context 'when the order is not paid' do
-        it 'raises an OrderNotPaidError' do
-          stub_configuration(capture_at_notification: false)
-          order = create_order_ready_to_ship(paid: false)
-
-          shipment_notice = build_shipment_notice(order.shipments.first)
-
-          expect { shipment_notice.apply }.to raise_error(SolidusShipstation::OrderNotPaidError)
-        end
+        expect { shipment_notice.apply }.to raise_error(SolidusShipstation::OrderNotPaidError)
       end
     end
   end
@@ -158,13 +107,5 @@ RSpec.describe SolidusShipstation::ShipmentNotice do
       shipment_number: shipment.number,
       shipment_tracking: shipment_tracking,
     )
-  end
-
-  def expect_order_to_be_shipped(order)
-    order.reload
-    expect(order.shipments.first).to be_shipped
-    expect(order.shipments.first.shipped_at).not_to be_nil
-    expect(order.shipments.first.tracking).to eq('1Z1231234')
-    expect(order.cartons.first.tracking).to eq('1Z1231234')
   end
 end


### PR DESCRIPTION
Fixes an issue that was causing the `ShipmentNotice` service object not to properly handle multiple webhooks for the same shipment number. Now, subsequent webhooks for the same shipment will simply update the tracking number, assuming that the label for that shipment was voided and recreated in ShipStation.

I also took the chance to refactor the spec for `ShipmentNotice` and reduce the amount of repeated code. I'm generally not a fan of using `let`, `before` or shared examples, but in this case it felt like the easiest way to make the spec easier to understand. This is most likely a sign that the class does too much stuff, but until we have time for a proper refactor the spec refactor should at least make the test easier to understand and change.