### PR TITLE
Deprecate Spree::Shipment decorators

### DIFF
--- a/app/controllers/spree/shipstation_controller.rb
+++ b/app/controllers/spree/shipstation_controller.rb
@@ -7,11 +7,13 @@ module Spree
     before_action :authenticate_shipstation
 
     def export
-      @shipments = Spree::Shipment
-                   .exportable
-                   .between(date_param(:start_date), date_param(:end_date))
-                   .page(params[:page])
-                   .per(50)
+      @shipments = SolidusShipstation::Shipment::ExportableQuery.apply(Spree::Shipment.all)
+      @shipments = SolidusShipstation::Shipment::BetweenQuery.apply(
+        @shipments,
+        from: date_param(:start_date),
+        to: date_param(:end_date),
+      )
+      @shipments = @shipments.page(params[:page]).per(50)
 
       respond_to do |format|
         format.xml { render layout: false }

--- a/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
@@ -18,12 +18,12 @@ module SolidusShipstation
         end
 
         def between(from, to)
-          condition = <<~SQL.squish
-            (spree_shipments.updated_at > :from AND spree_shipments.updated_at < :to) OR
-            (spree_orders.updated_at > :from AND spree_orders.updated_at < :to)
-          SQL
+          ::Spree::Deprecation.warn <<~DEPRECATION
+            `Spree::Shipment.between` is deprecated and will be removed in a future version
+            of solidus_shipstation. Please use `SolidusShipstation::Shipment::BetweenQuery.apply`.
+          DEPRECATION
 
-          joins(:order).where(condition, from: from, to: to)
+          SolidusShipstation::Shipment::BetweenQuery.apply(self, from: from, to: to)
         end
       end
 

--- a/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_shipstation/spree/shipment_decorator.rb
@@ -9,19 +9,12 @@ module SolidusShipstation
 
       module ClassMethods
         def exportable
-          query = order(:updated_at)
-                  .joins(:order)
-                  .merge(::Spree::Order.complete)
+          ::Spree::Deprecation.warn <<~DEPRECATION
+            `Spree::Shipment.exportable` is deprecated and will be removed in a future version
+            of solidus_shipstation. Please use `SolidusShipstation::Shipment::ExportableQuery.apply`.
+          DEPRECATION
 
-          unless SolidusShipstation.configuration.capture_at_notification
-            query = query.where(spree_shipments: { state: ['ready', 'canceled'] })
-          end
-
-          unless SolidusShipstation.configuration.export_canceled_shipments
-            query = query.where.not(spree_shipments: { state: 'canceled' })
-          end
-
-          query
+          SolidusShipstation::Shipment::ExportableQuery.apply(self)
         end
 
         def between(from, to)

--- a/app/queries/solidus_shipstation/shipment/between_query.rb
+++ b/app/queries/solidus_shipstation/shipment/between_query.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SolidusShipstation
+  module Shipment
+    class BetweenQuery
+      def self.apply(scope, from:, to:)
+        scope.joins(:order).where(<<~SQL.squish, from: from, to: to)
+          (spree_shipments.updated_at > :from AND spree_shipments.updated_at < :to) OR
+          (spree_orders.updated_at > :from AND spree_orders.updated_at < :to)
+        SQL
+      end
+    end
+  end
+end

--- a/app/queries/solidus_shipstation/shipment/exportable_query.rb
+++ b/app/queries/solidus_shipstation/shipment/exportable_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SolidusShipstation
+  module Shipment
+    class ExportableQuery
+      def self.apply(scope)
+        scope = scope
+                .order(:updated_at)
+                .joins(:order)
+                .merge(::Spree::Order.complete)
+
+        unless SolidusShipstation.configuration.capture_at_notification
+          scope = scope.where(spree_shipments: { state: ['ready', 'canceled'] })
+        end
+
+        unless SolidusShipstation.configuration.export_canceled_shipments
+          scope = scope.where.not(spree_shipments: { state: 'canceled' })
+        end
+
+        scope
+      end
+    end
+  end
+end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -2,30 +2,27 @@
 
 RSpec.describe Spree::Shipment do
   describe '.between' do
-    it 'returns shipments whose updated_at falls within the given time range' do
-      shipment = create(:shipment) { |s| s.update_column(:updated_at, Time.zone.now) }
+    it 'delegates to BetweenQuery' do
+      shipment = build_stubbed(:shipment)
+      allow(SolidusShipstation::Shipment::BetweenQuery).to receive(:apply).with(
+        any_args,
+        from: Time.zone.yesterday,
+        to: Time.zone.today,
+      ).and_return([shipment])
 
-      expect(described_class.between(Time.zone.yesterday, Time.zone.tomorrow)).to eq([shipment])
+      result = Spree::Deprecation.silence do
+        described_class.between(Time.zone.yesterday, Time.zone.today)
+      end
+
+      expect(result).to eq([shipment])
     end
 
-    it "returns shipments whose order's updated_at falls within the given time range" do
-      order = create(:order) { |o| o.update_column(:updated_at, Time.zone.now) }
-      shipment = create(:shipment, order: order)
+    it 'prints a deprecation warning' do
+      allow(Spree::Deprecation).to receive(:warn)
 
-      expect(described_class.between(Time.zone.yesterday, Time.zone.tomorrow)).to eq([shipment])
-    end
+      described_class.between(Time.zone.yesterday, Time.zone.today)
 
-    it 'does not return shipments whose updated_at does not fall within the given time range' do
-      create(:shipment) { |s| s.update_column(:updated_at, Time.zone.now) }
-
-      expect(described_class.between(Time.zone.tomorrow, Time.zone.tomorrow + 1.day)).to eq([])
-    end
-
-    it "does not return shipments whose order's updated_at falls within the given time range" do
-      order = create(:order) { |o| o.update_column(:updated_at, Time.zone.now) }
-      create(:shipment, order: order)
-
-      expect(described_class.between(Time.zone.tomorrow, Time.zone.tomorrow + 1.day)).to eq([])
+      expect(Spree::Deprecation).to have_received(:warn).with(/Spree::Shipment\.between/)
     end
   end
 

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -30,54 +30,23 @@ RSpec.describe Spree::Shipment do
   end
 
   describe '.exportable' do
-    context 'when capture_at_notification is false and export_canceled_shipments is false' do
-      it 'returns ready shipments from complete orders' do
-        stub_configuration(capture_at_notification: false, export_canceled_shipments: false)
+    it 'delegates to ExportableQuery' do
+      shipment = build_stubbed(:shipment)
+      allow(SolidusShipstation::Shipment::ExportableQuery).to receive(:apply).and_return([shipment])
 
-        ready_shipment = create(:order_ready_to_ship).shipments.first
-        create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
-        create(:shipped_order)
-
-        expect(described_class.exportable).to eq([ready_shipment])
+      result = Spree::Deprecation.silence do
+        described_class.exportable
       end
+
+      expect(result).to eq([shipment])
     end
 
-    context 'when capture_at_notification is true and export_canceled_shipments is false' do
-      it 'returns non-canceled shipments from complete orders' do
-        stub_configuration(capture_at_notification: true, export_canceled_shipments: false)
+    it 'prints a deprecation warning' do
+      allow(Spree::Deprecation).to receive(:warn)
 
-        ready_shipment = create(:order_ready_to_ship).shipments.first
-        shipped_shipment = create(:shipped_order).shipments.first
-        create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
+      described_class.exportable
 
-        expect(described_class.exportable).to eq([ready_shipment, shipped_shipment])
-      end
-    end
-
-    context 'when capture_at_notification is false and export_canceled_shipments is true' do
-      it 'returns ready and canceled shipments from complete orders' do
-        stub_configuration(capture_at_notification: false, export_canceled_shipments: true)
-
-        ready_shipment = create(:order_ready_to_ship).shipments.first
-        canceled_shipment = create(:order_ready_to_ship).shipments.first
-        canceled_shipment.cancel!
-        create(:shipped_order)
-
-        expect(described_class.exportable).to eq([ready_shipment, canceled_shipment])
-      end
-    end
-
-    context 'when capture_at_notification is true and export_canceled_shipments is true' do
-      it 'returns all shipments from complete orders' do
-        stub_configuration(capture_at_notification: true, export_canceled_shipments: true)
-
-        ready_shipment = create(:order_ready_to_ship).shipments.first
-        canceled_shipment = create(:order_ready_to_ship).shipments.first
-        canceled_shipment.cancel!
-        shipped_shipment = create(:shipped_order).shipments.first
-
-        expect(described_class.exportable).to eq([ready_shipment, canceled_shipment, shipped_shipment])
-      end
+      expect(Spree::Deprecation).to have_received(:warn).with(/Spree::Shipment\.exportable/)
     end
   end
 end

--- a/spec/queries/solidus_shipstation/shipment/between_query_spec.rb
+++ b/spec/queries/solidus_shipstation/shipment/between_query_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe SolidusShipstation::Shipment::BetweenQuery do
+  # rubocop:disable Rails/SkipsModelValidations
+  describe '.apply' do
+    it 'returns shipments whose updated_at falls within the given time range' do
+      shipment = create(:shipment) { |s| s.update_column(:updated_at, Time.zone.now) }
+
+      result = described_class.apply(
+        Spree::Shipment.all,
+        from: Time.zone.yesterday,
+        to: Time.zone.tomorrow,
+      )
+
+      expect(result).to eq([shipment])
+    end
+
+    it "returns shipments whose order's updated_at falls within the given time range" do
+      order = create(:order) { |o| o.update_column(:updated_at, Time.zone.now) }
+      shipment = create(:shipment, order: order)
+
+      result = described_class.apply(
+        Spree::Shipment.all,
+        from: Time.zone.yesterday,
+        to: Time.zone.tomorrow,
+      )
+
+      expect(result).to eq([shipment])
+    end
+
+    it 'does not return shipments whose updated_at does not fall within the given time range' do
+      create(:shipment) { |s| s.update_column(:updated_at, Time.zone.now) }
+
+      result = described_class.apply(
+        Spree::Shipment.all,
+        from: Time.zone.tomorrow,
+        to: Time.zone.tomorrow + 1.day,
+      )
+
+      expect(result).to eq([])
+    end
+
+    it "does not return shipments whose order's updated_at falls within the given time range" do
+      order = create(:order) { |o| o.update_column(:updated_at, Time.zone.now) }
+      create(:shipment, order: order)
+
+      result = described_class.apply(
+        Spree::Shipment.all,
+        from: Time.zone.tomorrow,
+        to: Time.zone.tomorrow + 1.day,
+      )
+
+      expect(result).to eq([])
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+end

--- a/spec/queries/solidus_shipstation/shipment/exportable_query_spec.rb
+++ b/spec/queries/solidus_shipstation/shipment/exportable_query_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe SolidusShipstation::Shipment::ExportableQuery do
+  describe '.apply' do
+    context 'when capture_at_notification is false and export_canceled_shipments is false' do
+      it 'returns ready shipments from complete orders' do
+        stub_configuration(capture_at_notification: false, export_canceled_shipments: false)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
+        create(:shipped_order)
+
+        expect(described_class.apply(Spree::Shipment.all)).to eq([ready_shipment])
+      end
+    end
+
+    context 'when capture_at_notification is true and export_canceled_shipments is false' do
+      it 'returns non-canceled shipments from complete orders' do
+        stub_configuration(capture_at_notification: true, export_canceled_shipments: false)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        shipped_shipment = create(:shipped_order).shipments.first
+        create(:order_ready_to_ship) { |o| o.shipments.first.cancel! }
+
+        expect(described_class.apply(Spree::Shipment.all)).to eq([ready_shipment, shipped_shipment])
+      end
+    end
+
+    context 'when capture_at_notification is false and export_canceled_shipments is true' do
+      it 'returns ready and canceled shipments from complete orders' do
+        stub_configuration(capture_at_notification: false, export_canceled_shipments: true)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment.cancel!
+        create(:shipped_order)
+
+        expect(described_class.apply(Spree::Shipment.all)).to eq([ready_shipment, canceled_shipment])
+      end
+    end
+
+    context 'when capture_at_notification is true and export_canceled_shipments is true' do
+      it 'returns all shipments from complete orders' do
+        stub_configuration(capture_at_notification: true, export_canceled_shipments: true)
+
+        ready_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment = create(:order_ready_to_ship).shipments.first
+        canceled_shipment.cancel!
+        shipped_shipment = create(:shipped_order).shipments.first
+
+        expect(described_class.apply(Spree::Shipment.all)).to eq([ready_shipment, canceled_shipment, shipped_shipment])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Whenever possible, we should avoid introducing decorators, since they pollute global namespaces and make it hard to understand where things are defined.

This extension defined two scopes on `Spree::Shipment` for its own convenience. These were extracted into proper query objects. The corresponding scopes have been maintained on `Spree::Shipment` with a deprecation warning.