### PR TITLE
API sync improvements

### DIFF
--- a/app/jobs/solidus_shipstation/api/schedule_shipment_syncs_job.rb
+++ b/app/jobs/solidus_shipstation/api/schedule_shipment_syncs_job.rb
@@ -11,6 +11,8 @@ module SolidusShipstation
         shipments.find_in_batches(batch_size: SolidusShipstation.config.api_batch_size) do |batch|
           SyncShipmentsJob.perform_later(batch.to_a)
         end
+      rescue StandardError => e
+        SolidusShipstation.config.error_handler.call(e, {})
       end
     end
   end

--- a/lib/generators/solidus_shipstation/install/templates/initializer.rb
+++ b/lib/generators/solidus_shipstation/install/templates/initializer.rb
@@ -31,6 +31,13 @@ SolidusShipstation.configure do |config|
   #   SolidusShipstation::Api::ShipmentSerializer.new(store_id: '12345678').call(shipment)
   # end
 
+  # Override the logic used to match a ShipStation order to a shipment from a
+  # given collection. This can be useful when you override the default serializer
+  # and change the logic used to generate the order number.
+  # config.api_shipment_matcher = proc do |shipstation_order, shipments|
+  #   shipments.find { |shipment| shipment.number == shipstation_order['orderNumber'] }
+  # end
+
   # Username and password for accessing the ShipStation API.
   # config.api_username = "api-user"
   # config.api_password = "api-pass"

--- a/lib/solidus_shipstation/configuration.rb
+++ b/lib/solidus_shipstation/configuration.rb
@@ -14,6 +14,7 @@ module SolidusShipstation
       :api_shipment_serializer,
       :api_username,
       :api_password,
+      :api_shipment_matcher,
       :error_handler,
     )
 
@@ -23,6 +24,9 @@ module SolidusShipstation
       @error_handler = ->(_error, _extra = {}) {
         Rails.logger.error "#{error.inspect} (#{extra.inspect})"
       }
+      @api_shipment_matcher = proc do |shipstation_order, shipments|
+        shipments.find { |shipment| shipment.number == shipstation_order['orderNumber'] }
+      end
     end
   end
 


### PR DESCRIPTION
Contains a couple of improvements to the API sync mechanism:

- Swallows any errors that happen in the scheduler background job. Since this job is enqueued periodically, allowing the job to be retried on error would cause the job queues to fill up pretty quickly.
- Allows configuring custom logic for matching the ShipStation response to the original shipments that were synced. This is useful when using a custom serializer that alters the order key in ShipStation in some way (e.g., by prefixing the shipment number with the current environment).