### PR TITLE
Swallow errors in `Api::SyncShipmentsJob`

### DIFF
--- a/app/jobs/solidus_shipstation/api/sync_shipments_job.rb
+++ b/app/jobs/solidus_shipstation/api/sync_shipments_job.rb
@@ -12,6 +12,8 @@ module SolidusShipstation
         sync_shipments(shipments)
       rescue RateLimitedError => e
         self.class.set(wait: e.retry_in).perform_later
+      rescue StandardError => e
+        SolidusShipstation.config.error_handler.call(e, {})
       end
 
       private

--- a/lib/generators/solidus_shipstation/install/templates/initializer.rb
+++ b/lib/generators/solidus_shipstation/install/templates/initializer.rb
@@ -38,9 +38,9 @@ SolidusShipstation.configure do |config|
   #   shipments.find { |shipment| shipment.number == shipstation_order['orderNumber'] }
   # end
 
-  # Username and password for accessing the ShipStation API.
-  # config.api_username = "api-user"
-  # config.api_password = "api-pass"
+  # API key and secret for accessing the ShipStation API.
+  # config.api_key = "api-key"
+  # config.api_secret = "api-secret"
 
   # Number of shipments to import into ShipStation at once.
   # If unsure, leave this set to 100, which is the maximum

--- a/lib/generators/solidus_shipstation/install/templates/initializer.rb
+++ b/lib/generators/solidus_shipstation/install/templates/initializer.rb
@@ -9,13 +9,13 @@ SolidusShipstation.configure do |config|
   # want to charge your customers at the time of shipment.
   config.capture_at_notification = false
 
-  ####### XML integration
-  # Only uncomment these lines if you're going to use the XML integration.
-
   # ShipStation expects the endpoint to be protected by HTTP Basic Auth.
   # Set the username and password you desire for ShipStation to use.
-  # config.username = "smoking_jay_cutler"
-  # config.password = "my-awesome-password"
+  config.username = "smoking_jay_cutler"
+  config.password = "my-awesome-password"
+
+  ####### XML integration
+  # Only uncomment these lines if you're going to use the XML integration.
 
   # Export canceled shipments to ShipStation
   # Set this to `true` if you want canceled shipments included in the endpoint.

--- a/lib/solidus_shipstation/api/request_runner.rb
+++ b/lib/solidus_shipstation/api/request_runner.rb
@@ -10,8 +10,8 @@ module SolidusShipstation
       class << self
         def from_config
           new(
-            username: SolidusShipstation.config.api_username,
-            password: SolidusShipstation.config.api_password,
+            username: SolidusShipstation.config.api_key,
+            password: SolidusShipstation.config.api_secret,
           )
         end
       end

--- a/lib/solidus_shipstation/configuration.rb
+++ b/lib/solidus_shipstation/configuration.rb
@@ -12,8 +12,8 @@ module SolidusShipstation
       :api_batch_size,
       :api_sync_threshold,
       :api_shipment_serializer,
-      :api_username,
-      :api_password,
+      :api_key,
+      :api_secret,
       :api_shipment_matcher,
       :error_handler,
     )

--- a/spec/lib/solidus_shipstation/api/request_runner_spec.rb
+++ b/spec/lib/solidus_shipstation/api/request_runner_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe SolidusShipstation::Api::RequestRunner do
   describe '.from_config' do
     it 'builds a runner using credentials from the configuration' do
-      stub_configuration(api_username: 'user', api_password: 'pass')
+      stub_configuration(api_key: 'user', api_secret: 'pass')
 
       request_runner = described_class.from_config
 


### PR DESCRIPTION
Handles any errors that happen when syncing a particular batch of shipments gracefully, by calling the error handler instead of bubbling up the error. Since shipment syncs are re-enqueued periodically, this prevents useless retries which would fill up the background job queue.

Also contains a couple of minor configuration updates.