### PR TITLE
Address: infer residential attribute from company

### DIFF
--- a/lib/solidus_shipstation/api/shipment_serializer.rb
+++ b/lib/solidus_shipstation/api/shipment_serializer.rb
@@ -60,6 +60,7 @@ module SolidusShipstation
           postalCode: address&.zipcode.to_s,
           country: address&.country&.iso.to_s,
           phone: address&.phone.to_s,
+          residential: address&.company.blank?
         }
       end
 

--- a/spec/lib/solidus_shipstation/api/shipment_serializer_spec.rb
+++ b/spec/lib/solidus_shipstation/api/shipment_serializer_spec.rb
@@ -8,5 +8,18 @@ RSpec.describe SolidusShipstation::Api::ShipmentSerializer do
 
       expect(result).to be_instance_of(Hash)
     end
+
+    it 'sets residential = false in address if company is given' do
+      order = create(:order_ready_to_ship,
+        bill_address: build(:address, company: 'ACME Co.'),
+        ship_address: build(:address, company: nil))
+      shipment = order.shipments.first
+
+      serializer = described_class.new(store_id: '12345678')
+      result = serializer.call(shipment)
+
+      expect(result[:billTo][:residential]).to be false
+      expect(result[:shipTo][:residential]).to be true
+    end
   end
 end


### PR DESCRIPTION
This PR implements very simple logic to transmit to ShipStation
whether an address is of the residential or business kind:
- if Company is set, it is a business address
- if Company is not set, it is a residential address