### PR TITLE
Allow ShipmentNotice class to be customized

### DIFF
--- a/app/controllers/spree/shipstation_controller.rb
+++ b/app/controllers/spree/shipstation_controller.rb
@@ -21,7 +21,8 @@ module Spree
     end
 
     def shipnotify
-      SolidusShipstation::ShipmentNotice.from_payload(params.to_unsafe_h).apply
+      shipment_notice_class = SolidusShipstation.configuration.shipment_notice_class.constantize
+      shipment_notice_class.from_payload(params.to_unsafe_h).apply
       head :ok
     rescue SolidusShipstation::Error => e
       head :bad_request

--- a/lib/generators/solidus_shipstation/install/templates/initializer.rb
+++ b/lib/generators/solidus_shipstation/install/templates/initializer.rb
@@ -21,6 +21,11 @@ SolidusShipstation.configure do |config|
   # Set this to `true` if you want canceled shipments included in the endpoint.
   # config.export_canceled_shipments = false
 
+  # You can customize the class used to receive notifications from the POST request
+  # Make sure it has a class method `from_payload` which receives the notification hash
+  # and an instance method `apply`
+  # config.shipment_notice_class = 'SolidusShipstation::ShipmentNotice'
+
   ####### API integration
   # Only uncomment these lines if you're going to use the API integration.
 

--- a/lib/solidus_shipstation/configuration.rb
+++ b/lib/solidus_shipstation/configuration.rb
@@ -16,6 +16,7 @@ module SolidusShipstation
       :api_secret,
       :api_shipment_matcher,
       :error_handler,
+      :shipment_notice_class
     )
 
     def initialize
@@ -27,6 +28,8 @@ module SolidusShipstation
       @api_shipment_matcher = proc do |shipstation_order, shipments|
         shipments.find { |shipment| shipment.number == shipstation_order['orderNumber'] }
       end
+
+      @shipment_notice_class = 'SolidusShipstation::ShipmentNotice'
     end
   end
 


### PR DESCRIPTION
Sometimes users might have specific logic related to the notification received on the XML integration. This change introduces a `shipment_notice_class` configuration so that users can customize such logic more easily.