### PR TITLE
Handle orders without a billing address

### DIFF
--- a/lib/solidus_shipstation/api/batch_syncer.rb
+++ b/lib/solidus_shipstation/api/batch_syncer.rb
@@ -40,6 +40,8 @@ module SolidusShipstation
           raise e
         end
 
+        return unless response
+
         response['results'].each do |shipstation_order|
           shipment = shipment_matcher.call(shipstation_order, shipments)
 

--- a/lib/solidus_shipstation/api/shipment_serializer.rb
+++ b/lib/solidus_shipstation/api/shipment_serializer.rb
@@ -51,15 +51,15 @@ module SolidusShipstation
 
       def serialize_address(address)
         {
-          name: SolidusSupport.combined_first_and_last_name_in_address? ? address.name : address.full_name,
-          company: address.company,
-          street1: address.address1,
-          street2: address.address2,
-          city: address.city,
-          state: address.state&.abbr,
-          postalCode: address.zipcode,
-          country: address.country&.iso,
-          phone: address.phone,
+          name: (SolidusSupport.combined_first_and_last_name_in_address? ? address&.name : address&.full_name).to_s,
+          company: address&.company.to_s,
+          street1: address&.address1.to_s,
+          street2: address&.address2.to_s,
+          city: address&.city.to_s,
+          state: address&.state&.abbr.to_s,
+          postalCode: address&.zipcode.to_s,
+          country: address&.country&.iso.to_s,
+          phone: address&.phone.to_s,
         }
       end
 


### PR DESCRIPTION
In Solidus, a billing address is not required for free orders. This PR ensures we handle this situation gracefully when syncing shipments by correctly sending null values to ShipStation, rather than crashing the sync.