### PR TITLE
Add message to SolidusShipStation::Api::RequestError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v2.0.0
+
+**Breaking changes**
+
+- The default message for a `RequestError` has been changed from the raw response body to a parsed version. If your code depends on the response body, you need to access it through the `.response_body` attribute on the exception instead.
+  ```ruby
+  # before
+  error.message
+  error.to_s
+
+  # after
+  error.response_body
+  ```
+
 ## [v1.1.0](https://github.com/solidusio-contrib/solidus_shipstation/tree/v1.1.0) (2021-10-26)
 
 [Full Changelog](https://github.com/solidusio-contrib/solidus_shipstation/compare/v1.0.0...v1.1.0)

--- a/lib/solidus_shipstation/api/request_error.rb
+++ b/lib/solidus_shipstation/api/request_error.rb
@@ -26,7 +26,18 @@ module SolidusShipstation
         @response_body = response_body
         @response_headers = response_headers
 
-        super(response_body)
+        super(message_from_body)
+      end
+
+      private
+
+      def message_from_body
+        return unless @response_body
+
+        parsed_body = JSON.parse(@response_body)
+        exception_type = parsed_body.fetch('ExceptionType', 'Unknown Exception Type')
+        exception_message = parsed_body.fetch('ExceptionMessage', '')
+        "#{exception_type}: #{exception_message}"
       end
     end
   end

--- a/spec/lib/solidus_shipstation/api/request_error_spec.rb
+++ b/spec/lib/solidus_shipstation/api/request_error_spec.rb
@@ -17,4 +17,45 @@ RSpec.describe SolidusShipstation::Api::RequestError do
       )
     end
   end
+
+  describe '.message' do
+    it 'returns the name of the exception if there is no message body' do
+      response = instance_double(
+        'HTTParty::Response',
+        code: 500,
+        headers: { 'Key' => 'Value' },
+        body: nil
+      )
+
+      error = described_class.from_response(response)
+
+      expect(error.message).to eq("SolidusShipstation::Api::RequestError")
+    end
+
+    it 'extracts both the ExceptionMessage and ExceptionType' do
+      response = instance_double(
+        'HTTParty::Response',
+        code: 500,
+        headers: { 'Key' => 'Value' },
+        body: '{ "Message": "An error has occured.", "ExceptionMessage": "orders are required", "ExceptionType": "System.ArgumentException" }',
+      )
+
+      error = described_class.from_response(response)
+
+      expect(error.message).to eq("System.ArgumentException: orders are required")
+    end
+
+    it 'doesn\'t fail when the ExceptionMessage and ExceptionType are missing' do
+      response = instance_double(
+        'HTTParty::Response',
+        code: 500,
+        headers: { 'Key' => 'Value' },
+        body: '{ "Message": "An error has occured." }',
+      )
+
+      error = described_class.from_response(response)
+
+      expect(error.message).to eq("Unknown Exception Type: ")
+    end
+  end
 end

--- a/spec/lib/solidus_shipstation/api/request_error_spec.rb
+++ b/spec/lib/solidus_shipstation/api/request_error_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SolidusShipstation::Api::RequestError do
         'HTTParty::Response',
         code: 500,
         headers: { 'Key' => 'Value' },
-        body: '{ "message": "Internal Server Error" }',
+        body: '{ "Message": "An error has occured.", "ExceptionMessage": "orders are required", "ExceptionType": "System.ArgumentException" }',
       )
 
       error = described_class.from_response(response)
@@ -13,7 +13,7 @@ RSpec.describe SolidusShipstation::Api::RequestError do
       expect(error).to have_attributes(
         response_code: 500,
         response_headers: { 'Key' => 'Value' },
-        response_body: '{ "message": "Internal Server Error" }',
+        response_body: '{ "Message": "An error has occured.", "ExceptionMessage": "orders are required", "ExceptionType": "System.ArgumentException" }',
       )
     end
   end


### PR DESCRIPTION
The commit message explains it best:

Sentry uses `.message`[^1] to set the value on their error messages. The method exists by default on `Exception` (from which `RequestError` inherits).  By default it returns the message provided to the initialiser of `RequestError`.  This PR introduces better formatting of this message to allow it to be picked up better by Sentry.

[^1]: https://github.com/getsentry/sentry-ruby/blob/94c28fe9a7fd1c15a10eeeb0e1c4fcac099d4166/sentry-ruby/lib/sentry/interfaces/single_exception.rb#L7
