### PR TITLE
Retry Sync on error

### DIFF
--- a/lib/generators/solidus_shipstation/install/templates/initializer.rb
+++ b/lib/generators/solidus_shipstation/install/templates/initializer.rb
@@ -64,4 +64,10 @@ SolidusShipstation.configure do |config|
   # config.error_handler = -> (error, context = {}) {
   #   Sentry.capture_exception(error, extra: context)
   # }
+
+  # API call attempts before reporting an error using the error
+  # handler. Using a larger number can decrease the throughput of your
+  # API but reduce the amount of false positives in your error
+  # reporting.
+  # config.api_request_attempts = 1
 end

--- a/lib/solidus_shipstation/configuration.rb
+++ b/lib/solidus_shipstation/configuration.rb
@@ -15,6 +15,7 @@ module SolidusShipstation
       :api_key,
       :api_secret,
       :api_shipment_matcher,
+      :api_request_attempts,
       :error_handler,
       :shipment_notice_class
     )
@@ -22,6 +23,7 @@ module SolidusShipstation
     def initialize
       @api_batch_size = 100
       @api_sync_threshold = 7.days
+      @api_request_attempts = 1
       @error_handler = ->(_error, _extra = {}) {
         Rails.logger.error "#{error.inspect} (#{extra.inspect})"
       }


### PR DESCRIPTION
From our experience at my current project there have been several errors coming out of the ShipStation API that were resolved on a second try (through sidekiq retries).  This creates noise in our error tracking solution (Sentry) as these seem to be internal errors to ShipStation.  

This PR proposes a way to enable retrying a request a certain number of times before reporting an error.  This comes at the cost that errors during the retry-session are not captured (as intended).

The changes are implemented such that behaviour stays the same upon upgrading, only when `api_request_attempts` is set to a value larger than 1 will the retry-logic be used.

We also do not retry the request if the response was a RateLimitedError.

I'm open to thoughts and suggestions.